### PR TITLE
openai is needed for building

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"next": ">=14.1.1",
 		"next-sitemap": "^4.2.3",
 		"next-transpile-modules": "^10.0.1",
+		"openai": "^4.51.0",
 		"papaparse": "^5.4.1",
 		"postcss": ">=8.4.31",
 		"posthog-js": "^1.93.2",


### PR DESCRIPTION
just added openai to the package.json. Without that there is a build error.